### PR TITLE
Add Terraform script for creating a Sandbox Keycloak service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 .terraform
 tdr-terraform-modules
+*.tfstate
+*.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## TDR Scripts
 
-This is a repository for scripts which are run infrequently and don't belong with other projects. 
+This is a repository for scripts which are run infrequently and don't belong with other projects.
 Terraform scripts are put into separate directories inside the terraform directories. Other non-terraform scripts can be organised as and when we need them.
 
 ### Bastion host creation script
-This is a terraform script to create a bastion host which can be used to connect to the database. 
+This is a terraform script to create a bastion host which can be used to connect to the database.
 Postgres client is installed when the instance is created and a .pgpass file is created to store the login credentials on the host. The host disk drive is encrypted.
 The `terraform/bastion` directory contains a Jenkinsfile for creating the bastion instance through Jenkins.
 
@@ -28,7 +28,7 @@ To setup an ssh tunnel
 host i-* mi-*
     ProxyCommand sh -c "aws ssm start-session --profile integration --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
 ```
-* Get the instance id from the instances page in the console or by running 
+* Get the instance id from the instances page in the console or by running
 `aws ec2 describe-instances --filters Name=instance-state-name,Values=running Name=tag:Name,Values=bastion-ec2-instance-intg`
 
 * Run the ssh tunnel
@@ -39,3 +39,14 @@ host i-* mi-*
 [ec2-instances]: https://eu-west-2.console.aws.amazon.com/ec2/v2/home?region=eu-west-2#Instances
 [ssh-key-pair]: https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
 [bastion-jenkins-job]: https://jenkins.tdr-management.nationalarchives.gov.uk/job/TDR%20Bastion%20Deploy/
+
+### Keycloak Sandbox
+
+Terraform script for creating a temporary Keycloak instance in the Sandbox
+environment. This instance does not have all of the security protections used
+in the integration/staging/production version of Keycloak, so it should only be
+used for testing new Keycloak configuration.
+
+See the [Keycloak Sandbox Readme](keycloak-sandbox) for setup instructions.
+
+[keycloak-sandbox]: terraform/keycloak-sandbox/README.md

--- a/terraform/keycloak-sandbox/README.md
+++ b/terraform/keycloak-sandbox/README.md
@@ -42,6 +42,35 @@ If you have any conflicts with existing resources, the most likely cause is that
 someone else has run this script recently and hasn't run `terraform destroy`
 yet.
 
+Upload the Keycloak image to ECR. If you want to use the current intg image,
+download it from the mgmt account, replacing the account number in the following
+commands:
+
+```
+aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin <mgmt-account-number>.dkr.ecr.eu-west-2.amazonaws.com
+docker pull <mgmt-account-number>.dkr.ecr.eu-west-2.amazonaws.com/auth-server:intg
+```
+
+Then retag it and upload it to the Sandbox account, replacing the account
+numbers in the following commands:
+
+```
+docker tag <mgmt-account-number>.dkr.ecr.eu-west-2.amazonaws.com/auth-server:intg <sandbox-account-number>.dkr.ecr.eu-west-2.amazonaws.com/keycloak_sandbox:latest
+docker push <sandbox-account-number>.dkr.ecr.eu-west-2.amazonaws.com/keycloak_sandbox:latest
+```
+
+Alternatively, if you want to test a modified version of the Docker image, build
+it locally then tag and push it as above.
+
+Then restart the ECS service:
+
+```
+aws ecs update-service \
+  --service keycloak_service_sandbox \
+  --cluster keycloak_sandbox \
+  --force-new-deployment
+```
+
 Check the Keycloak ECS service in the AWS console to check that it has started
 up correctly. Once it has, look up the URL of the load balancer:
 

--- a/terraform/keycloak-sandbox/README.md
+++ b/terraform/keycloak-sandbox/README.md
@@ -1,0 +1,119 @@
+# Run a Keycloak instance in the sandbox
+
+This Terraform script lets you create a Keycloak instance in the Sandbox
+account. This instance does not have all of the security controls that the
+Keycloak instances in the other accounts have. For example, the ECS app runs in
+a public subnet rather than a private subnet, the database has a public IP, and
+Keycloak only supports HTTP because we do not currently have a subdomain or SSL
+certificates for the Sandbox account. This means it is only suitable for testing
+out Keycloak configuration changes. It should **never be used to store real
+data** or connected to a non-Sandbox service. The Keycloak instance in other
+environments should have been created by [tdr-terraform-environments].
+
+This script is intended to be run from a development machine rather than
+Jenkins.
+
+For simplicity, the Terraform script uses a local Terraform state rather than
+storing the state in a shared S3 bucket. This means only one person can spin up
+the Keycloak server at once. If that turns out to be a problem, we can
+reconfigure this project to use a shared state.
+
+Remember to tear down the resources once they are not needed.
+
+[tdr-terraform-environments]: https://github.com/nationalarchives/tdr-terraform-environments
+
+## Create and configure the instance
+
+Get AWS credentials for the Sandbox environment by signing in via AWS SSO.
+
+Initialise the project:
+
+```
+terraform init
+```
+
+Create the AWS resources:
+
+```
+terraform apply
+```
+
+If you have any conflicts with existing resources, the most likely cause is that
+someone else has run this script recently and hasn't run `terraform destroy`
+yet.
+
+Check the Keycloak ECS service in the AWS console to check that it has started
+up correctly. Once it has, look up the URL of the load balancer:
+
+```
+aws elbv2 describe-load-balancers --names "keycloak-sandbox" | grep DNSName
+```
+
+Visit this URL in your browser to check that Keycloak is running.
+
+Give yourself temporary access to the database:
+
+```
+aws ec2 authorize-security-group-ingress \
+  --group-name "keycloak-database-security-group-sandbox" \
+  --protocol tcp \
+  --port 5432 \
+  --cidr <your IP address>/32
+```
+
+Look up the address of the Keycloak database instance:
+
+```
+aws rds describe-db-instances | grep Address
+```
+
+Get the DB account password from systems manager:
+
+```
+aws ssm get-parameter --name "/sandbox/keycloak/database/password" --with-decryption
+```
+
+Connect to the DB instance, and enter the password when prompted:
+
+```
+psql --host=<DB instance address> \
+  --port=5432 --user=keycloak_admin --password --dbname keycloak
+```
+
+Allow HTTP traffic to Keycloak. This is only safe in the Sandbox environment
+where no real data will be stored. Never run this in a non-Sandbox environment!
+
+```
+UPDATE realm SET ssl_required='NONE' WHERE id = 'master';
+UPDATE realm SET ssl_required='NONE' WHERE id = 'tdr';
+```
+
+Then restart the ECS service:
+
+```
+aws ecs update-service \
+  --service keycloak_service_sandbox \
+  --cluster keycloak_sandbox \
+  --force-new-deployment
+```
+
+Then run `terraform apply` to revert the security group change.
+
+Get the Keycloak admin account details:
+
+```
+aws ssm get-parameters \
+  --names "/sandbox/keycloak/admin/user" "/sandbox/keycloak/admin/password" \
+  --with-decryption
+```
+
+Visit the Keycloak load balancer URL again, and sign into the admin UI using the
+username and password you just fetched.
+
+## Delete the instance
+
+Run:
+
+```
+terraform destroy
+```

--- a/terraform/keycloak-sandbox/database.tf
+++ b/terraform/keycloak-sandbox/database.tf
@@ -1,0 +1,87 @@
+resource "random_password" "password" {
+  length  = 16
+  special = false
+}
+
+resource "random_string" "snapshot_prefix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+resource "aws_rds_cluster" "keycloak_database" {
+  cluster_identifier_prefix       = "keycloak-db-postgres-${var.environment}"
+  engine                          = "aurora-postgresql"
+  engine_version                  = "11.6"
+  availability_zones              = ["eu-west-2a", "eu-west-2b"]
+  database_name                   = "keycloak"
+  master_username                 = "keycloak_admin"
+  final_snapshot_identifier       = "keycloak-db-final-snapshot-${random_string.snapshot_prefix.result}-${var.environment}"
+  master_password                 = random_password.password.result
+  vpc_security_group_ids          = aws_security_group.database.*.id
+  db_subnet_group_name            = aws_db_subnet_group.user_subnet_group.name
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+  tags = merge(
+    local.common_tags,
+    map(
+      "Name", "keycloak-db-cluster-${var.environment}"
+    )
+  )
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to availability zones because AWS automatically adds the
+      # extra availability zone "eu-west-2c", which is rejected by the API as
+      # unavailable if specified directly.
+      availability_zones,
+    ]
+  }
+}
+
+resource "aws_rds_cluster_instance" "user_database_instance" {
+  count                = 1
+  identifier_prefix    = "keycloak-db-postgres-instance-${var.environment}"
+  cluster_identifier   = aws_rds_cluster.keycloak_database.id
+  engine               = "aurora-postgresql"
+  engine_version       = "11.6"
+  instance_class       = "db.t3.medium"
+  publicly_accessible  = true
+  db_subnet_group_name = aws_db_subnet_group.user_subnet_group.name
+}
+
+resource "aws_db_subnet_group" "user_subnet_group" {
+  name       = "main-${var.environment}"
+  subnet_ids = local.subnet_ids
+
+  tags = merge(
+    local.common_tags,
+    map(
+      "Name", "user-db-subnet-group-${var.environment}"
+    )
+  )
+}
+
+resource "aws_security_group" "database" {
+  name        = "keycloak-database-security-group-${var.environment}"
+  description = "Allow inbound access from the keycloak load balancer only"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 5432
+    to_port         = 5432
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
+  egress {
+    protocol        = "-1"
+    from_port       = 0
+    to_port         = 0
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
+  tags = merge(
+    local.common_tags,
+    map("Name", "keycloak-database-security-group-${var.environment}")
+  )
+}

--- a/terraform/keycloak-sandbox/iam.tf
+++ b/terraform/keycloak-sandbox/iam.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "keycloak_ecs_execution" {
 
 resource "aws_iam_role" "keycloak_ecs_task" {
   name               = "keycloak_ecs_task_role_${var.environment}"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+  assume_role_policy = templatefile("./templates/ecs_assume_role_policy.json.tpl", {})
 
   tags = merge(
     local.common_tags,
@@ -49,19 +49,5 @@ resource "aws_iam_role_policy_attachment" "keycloak_ecs_execution" {
 resource "aws_iam_policy" "keycloak_ecs_execution" {
   name   = "keycloak_ecs_execution_policy_${var.environment}"
   path   = "/"
-  policy = data.aws_iam_policy_document.keycloak_ecs_execution.json
-}
-
-data "aws_iam_policy_document" "keycloak_ecs_execution" {
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-    resources = ["arn:aws:logs:*"]
-  }
-  statement {
-    actions   = ["ecr:GetAuthorizationToken"]
-    resources = ["*"]
-  }
+  policy = templatefile("./templates/ecs_execution_policy.json.tpl", {})
 }

--- a/terraform/keycloak-sandbox/iam.tf
+++ b/terraform/keycloak-sandbox/iam.tf
@@ -60,4 +60,8 @@ data "aws_iam_policy_document" "keycloak_ecs_execution" {
     ]
     resources = ["arn:aws:logs:*"]
   }
+  statement {
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
 }

--- a/terraform/keycloak-sandbox/iam.tf
+++ b/terraform/keycloak-sandbox/iam.tf
@@ -1,0 +1,63 @@
+resource "aws_iam_role" "keycloak_ecs_execution" {
+  name               = "keycloak_ecs_execution_role_${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = merge(
+    local.common_tags,
+    map(
+      "Name", "api-ecs-execution-iam-role-${var.environment}",
+    )
+  )
+}
+
+resource "aws_iam_role" "keycloak_ecs_task" {
+  name               = "keycloak_ecs_task_role_${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = merge(
+    local.common_tags,
+    map(
+      "Name", "api-ecs-task-iam-role-${var.environment}",
+    )
+  )
+}
+
+data "aws_iam_policy_document" "ecs_assume_role" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "keycloak_ecs_execution_ssm" {
+  role       = aws_iam_role.keycloak_ecs_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "keycloak_ecs_execution" {
+  role       = aws_iam_role.keycloak_ecs_execution.name
+  policy_arn = aws_iam_policy.keycloak_ecs_execution.arn
+}
+
+resource "aws_iam_policy" "keycloak_ecs_execution" {
+  name   = "keycloak_ecs_execution_policy_${var.environment}"
+  path   = "/"
+  policy = data.aws_iam_policy_document.keycloak_ecs_execution.json
+}
+
+data "aws_iam_policy_document" "keycloak_ecs_execution" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = ["arn:aws:logs:*"]
+  }
+}

--- a/terraform/keycloak-sandbox/image.tf
+++ b/terraform/keycloak-sandbox/image.tf
@@ -9,7 +9,7 @@ resource "aws_ecr_repository" "ecr_repository" {
 }
 
 resource "aws_ecr_repository_policy" "ecr" {
-  policy     = templatefile(
+  policy = templatefile(
     "./templates/ecr_policy.json.tpl",
     { ecs_execution_role = aws_iam_role.keycloak_ecs_execution.arn }
   )

--- a/terraform/keycloak-sandbox/image.tf
+++ b/terraform/keycloak-sandbox/image.tf
@@ -1,0 +1,17 @@
+resource "aws_ecr_repository" "ecr_repository" {
+  name = "keycloak_sandbox"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_ecr_repository_policy" "ecr" {
+  policy     = templatefile(
+    "./templates/ecr_policy.json.tpl",
+    { ecs_execution_role = aws_iam_role.keycloak_ecs_execution.arn }
+  )
+  repository = aws_ecr_repository.ecr_repository.name
+}

--- a/terraform/keycloak-sandbox/load_balancer.tf
+++ b/terraform/keycloak-sandbox/load_balancer.tf
@@ -1,0 +1,70 @@
+resource "aws_alb" "keycloak" {
+  name            = "keycloak-${var.environment}"
+  subnets         = local.subnet_ids
+  security_groups = [aws_security_group.load_balancer.id]
+
+  tags = merge(
+    local.common_tags,
+    map("Name", "keycloak-${var.environment}")
+  )
+}
+
+resource "aws_alb_target_group" "keycloak" {
+  name        = "keycloak-${var.environment}"
+  port        = 8080
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = local.vpc_id
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "30"
+    protocol            = "HTTP"
+    matcher             = "200,303"
+    timeout             = "3"
+    path                = "/"
+    unhealthy_threshold = 2
+  }
+  tags = merge(
+    local.common_tags,
+    map("Name", "keycloak-${var.environment}")
+  )
+  depends_on = [aws_alb.keycloak]
+}
+
+resource "aws_security_group" "load_balancer" {
+  name        = "keycloak-load-balancer-security-group"
+  description = "Controls access to the keycloak load balancer"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    local.common_tags,
+    map("Name", "keycloak-load-balancer-security-group-${var.environment}")
+  )
+}
+
+# Use HTTP so we don't have to create a certificate in the Sandbox environment.
+# This is not ideal, but this Sandbox ALB will not be used for real data.
+resource "aws_alb_listener" "keycloak_http" {
+  load_balancer_arn = aws_alb.keycloak.id
+  port              = 80
+
+  default_action {
+    target_group_arn = aws_alb_target_group.keycloak.id
+    type             = "forward"
+  }
+}

--- a/terraform/keycloak-sandbox/parameter_store.tf
+++ b/terraform/keycloak-sandbox/parameter_store.tf
@@ -1,0 +1,78 @@
+resource "random_uuid" "client_secret" {}
+resource "random_uuid" "backend_checks_client_secret" {}
+
+resource "aws_ssm_parameter" "database_url" {
+  name  = "/${var.environment}/keycloak/database/url"
+  type  = "SecureString"
+  value = aws_rds_cluster.keycloak_database.endpoint
+}
+
+resource "aws_ssm_parameter" "database_username" {
+  name  = "/${var.environment}/keycloak/database/username"
+  type  = "SecureString"
+  value = aws_rds_cluster.keycloak_database.master_username
+}
+
+resource "aws_ssm_parameter" "database_password" {
+  name  = "/${var.environment}/keycloak/database/password"
+  type  = "SecureString"
+  value = aws_rds_cluster.keycloak_database.master_password
+}
+
+resource "aws_ssm_parameter" "keycloak_admin_password" {
+  name  = "/${var.environment}/keycloak/admin/password"
+  type  = "SecureString"
+  value = random_password.password.result
+}
+
+resource "aws_ssm_parameter" "keycloak_admin_user" {
+  name  = "/${var.environment}/keycloak/admin/user"
+  type  = "SecureString"
+  value = "tdr-keycloak-admin-${var.environment}"
+}
+
+resource "aws_ssm_parameter" "keycloak_client_secret" {
+  name  = "/${var.environment}/keycloak/client/secret"
+  type  = "SecureString"
+  value = random_uuid.client_secret.result
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "keycloak_realm_admin_client_secret" {
+  name  = "/${var.environment}/keycloak/realm_admin_client/secret"
+  type  = "SecureString"
+  value = random_uuid.backend_checks_client_secret.result
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "keycloak_backend_checks_client_secret" {
+  name  = "/${var.environment}/keycloak/backend_checks_client/secret"
+  type  = "SecureString"
+  value = random_uuid.backend_checks_client_secret.result
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "keycloak_configuration_properties" {
+  name  = "/${var.environment}/keycloak/configuration_properties"
+  type  = "String"
+  value = "intg_properties.json"
+}
+
+resource "aws_ssm_parameter" "keycloak_user_admin_client_secret" {
+  name  = "/${var.environment}/keycloak/user_admin_client/secret"
+  type  = "SecureString"
+  value = random_uuid.backend_checks_client_secret.result
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/terraform/keycloak-sandbox/root.tf
+++ b/terraform/keycloak-sandbox/root.tf
@@ -1,0 +1,106 @@
+resource "aws_ecs_cluster" "keycloak_ecs" {
+  name = "keycloak_${var.environment}"
+
+  tags = merge(
+    local.common_tags,
+    map("Name", "keycloak_${var.environment}")
+  )
+}
+
+resource "aws_ecs_task_definition" "keycloak_task" {
+  family                   = "keycloak-${var.environment}"
+  execution_role_arn       = aws_iam_role.keycloak_ecs_execution.arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 1024
+  memory                   = 3072
+  container_definitions    = data.template_file.app.rendered
+  task_role_arn            = aws_iam_role.keycloak_ecs_task.arn
+
+  tags = merge(
+    local.common_tags,
+    map("Name", "keycloak-task-definition")
+  )
+}
+
+resource "aws_ecs_service" "keycloak_service" {
+  name                              = "keycloak_service_${var.environment}"
+  cluster                           = aws_ecs_cluster.keycloak_ecs.id
+  task_definition                   = aws_ecs_task_definition.keycloak_task.arn
+  desired_count                     = 1
+  launch_type                       = "FARGATE"
+  health_check_grace_period_seconds = "360"
+
+  network_configuration {
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    subnets          = local.subnet_ids
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.keycloak.arn
+    container_name   = "keycloak"
+    container_port   = 8080
+  }
+
+  depends_on = [aws_alb_target_group.keycloak]
+}
+
+data "template_file" "app" {
+  template = file("templates/keycloak.json.tpl")
+
+  vars = {
+    # Deploy the latest integration image
+    app_image                         = "nationalarchives/tdr-auth-server:intg"
+    app_port                          = 8080
+    app_environment                   = var.environment
+    aws_region                        = local.aws_region
+    url_path                          = aws_ssm_parameter.database_url.name
+    username_path                     = aws_ssm_parameter.database_username.name
+    password_path                     = aws_ssm_parameter.database_password.name
+    admin_user_path                   = aws_ssm_parameter.keycloak_admin_user.name
+    admin_password_path               = aws_ssm_parameter.keycloak_admin_password.name
+    client_secret_path                = aws_ssm_parameter.keycloak_client_secret.name
+    backend_checks_client_secret_path = aws_ssm_parameter.keycloak_backend_checks_client_secret.name
+    realm_admin_client_secret_path    = aws_ssm_parameter.keycloak_realm_admin_client_secret.name
+    frontend_url                      = local.frontend_url
+    configuration_properties_path     = aws_ssm_parameter.keycloak_configuration_properties.name
+    user_admin_client_secret_path     = aws_ssm_parameter.keycloak_user_admin_client_secret.name
+  }
+}
+
+# Traffic to the ECS cluster should only come from the application load balancer
+resource "aws_security_group" "ecs_tasks" {
+  name        = "keycloak-ecs-tasks-security-group-${var.environment}"
+  description = "Allow inbound access from the keycloak load balancer only"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 8080
+    to_port         = 8080
+    security_groups = [aws_security_group.load_balancer.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    local.common_tags,
+    map("Name", "keycloak-ecs-task-security-group-${var.environment}")
+  )
+}
+
+resource "aws_cloudwatch_log_group" "keycloak_log_group" {
+  name              = "/ecs/keycloak-${var.environment}"
+  retention_in_days = 30
+}
+
+resource "aws_cloudwatch_log_stream" "tdr_application_log_stream" {
+  name           = "tdr-keycloak-stream-${var.environment}"
+  log_group_name = aws_cloudwatch_log_group.keycloak_log_group.name
+}

--- a/terraform/keycloak-sandbox/root.tf
+++ b/terraform/keycloak-sandbox/root.tf
@@ -51,7 +51,7 @@ data "template_file" "app" {
 
   vars = {
     # Deploy the latest integration image
-    app_image                         = "nationalarchives/tdr-auth-server:intg"
+    app_image                         = "${aws_ecr_repository.ecr_repository.repository_url}:latest"
     app_port                          = 8080
     app_environment                   = var.environment
     aws_region                        = local.aws_region

--- a/terraform/keycloak-sandbox/root_data.tf
+++ b/terraform/keycloak-sandbox/root_data.tf
@@ -1,0 +1,3 @@
+data "aws_ssm_parameter" "cost_centre" {
+  name = "/sandbox/cost_centre"
+}

--- a/terraform/keycloak-sandbox/root_locals.tf
+++ b/terraform/keycloak-sandbox/root_locals.tf
@@ -1,15 +1,15 @@
 locals {
-  environment  = var.environment
-  tag_prefix   = "test-keycloak"
-  aws_region   = "eu-west-2"
+  environment = var.environment
+  tag_prefix  = "test-keycloak"
+  aws_region  = "eu-west-2"
   # The default VPC in the Sandbox environment
-  vpc_id       = "vpc-04f38e6c"
+  vpc_id = "vpc-04f38e6c"
   # Public subnets in the default VPC
-  subnet_ids   = ["subnet-7706850d", "subnet-a4d706e8"]
+  subnet_ids = ["subnet-7706850d", "subnet-a4d706e8"]
   # We don't normally need to connect this Keycloak server to any other
   # services, so it's fine to use a placeholder URL
   frontend_url = "https://example.com"
-  common_tags  = map(
+  common_tags = map(
     "Environment", var.environment,
     "Owner", "TDR",
     "Terraform", true,

--- a/terraform/keycloak-sandbox/root_locals.tf
+++ b/terraform/keycloak-sandbox/root_locals.tf
@@ -1,0 +1,18 @@
+locals {
+  environment  = var.environment
+  tag_prefix   = "test-keycloak"
+  aws_region   = "eu-west-2"
+  # The default VPC in the Sandbox environment
+  vpc_id       = "vpc-04f38e6c"
+  # Public subnets in the default VPC
+  subnet_ids   = ["subnet-7706850d", "subnet-a4d706e8"]
+  # We don't normally need to connect this Keycloak server to any other
+  # services, so it's fine to use a placeholder URL
+  frontend_url = "https://example.com"
+  common_tags  = map(
+    "Environment", var.environment,
+    "Owner", "TDR",
+    "Terraform", true,
+    "CostCentre", data.aws_ssm_parameter.cost_centre.value
+  )
+}

--- a/terraform/keycloak-sandbox/root_provider.tf
+++ b/terraform/keycloak-sandbox/root_provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = local.aws_region
+}

--- a/terraform/keycloak-sandbox/root_variables.tf
+++ b/terraform/keycloak-sandbox/root_variables.tf
@@ -1,0 +1,3 @@
+variable "environment" {
+  default = "sandbox"
+}

--- a/terraform/keycloak-sandbox/templates/ecr_policy.json.tpl
+++ b/terraform/keycloak-sandbox/templates/ecr_policy.json.tpl
@@ -1,0 +1,19 @@
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPullConsignmentAPI",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "${ecs_execution_role}"
+        ]
+      },
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer"
+      ]
+    }
+  ]
+}

--- a/terraform/keycloak-sandbox/templates/ecs_assume_role_policy.json.tpl
+++ b/terraform/keycloak-sandbox/templates/ecs_assume_role_policy.json.tpl
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Sid": ""
+    }
+  ]
+}

--- a/terraform/keycloak-sandbox/templates/ecs_execution_policy.json.tpl
+++ b/terraform/keycloak-sandbox/templates/ecs_execution_policy.json.tpl
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*"
+    },
+    {
+      "Sid": "EcrAuthToken",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/terraform/keycloak-sandbox/templates/keycloak.json.tpl
+++ b/terraform/keycloak-sandbox/templates/keycloak.json.tpl
@@ -1,0 +1,78 @@
+[
+  {
+    "name": "keycloak",
+    "image": "${app_image}",
+    "cpu": 0,
+    "secrets": [
+      {
+        "valueFrom": "${url_path}",
+        "name": "DB_ADDR"
+      },
+      {
+        "valueFrom": "${username_path}",
+        "name": "DB_USER"
+      },
+      {
+        "valueFrom": "${password_path}",
+        "name": "DB_PASSWORD"
+      },
+      {
+        "valueFrom": "${admin_user_path}",
+        "name": "KEYCLOAK_USER"
+      },
+      {
+        "valueFrom": "${admin_password_path}",
+        "name": "KEYCLOAK_PASSWORD"
+      },
+      {
+        "valueFrom" : "${client_secret_path}",
+        "name": "CLIENT_SECRET"
+      },
+      {
+        "valueFrom": "${backend_checks_client_secret_path}",
+        "name": "BACKEND_CHECKS_CLIENT_SECRET"
+      },
+      {
+        "valueFrom": "${realm_admin_client_secret_path}",
+        "name": "REALM_ADMIN_CLIENT_SECRET"
+      },
+      {
+        "valueFrom": "${configuration_properties_path}",
+        "name": "KEYCLOAK_CONFIGURATION_PROPERTIES"
+      },
+      {
+        "valueFrom": "${user_admin_client_secret_path}",
+        "name": "USER_ADMIN_CLIENT_SECRET"
+      }
+    ],
+    "environment": [
+      {
+        "name" : "FRONTEND_URL",
+        "value" : "${frontend_url}"
+      },
+      {
+        "name" : "DB_VENDOR",
+        "value" : "postgres"
+      },
+      {
+        "name" : "KEYCLOAK_IMPORT",
+        "value": "/tmp/tdr-realm.json"
+      }
+    ],
+    "networkMode": "awsvpc",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "/ecs/keycloak-${app_environment}",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "ecs"
+      }
+    },
+    "portMappings": [
+      {
+        "containerPort": 8080,
+        "hostPort": 8080
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Add a script which lets us create a temporary Keycloak server in the Sandbox account. This will let us test configuration updates without breaking integration.