### PR TITLE
Add Jenkinsfile to configure CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .idea
 .terraform
 tdr-terraform-modules

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,6 @@
+library("tdr-jenkinslib")
+
+terraformCheckJob(
+  repo: "tdr-scripts",
+  terraformDirectoryPath: "./terraform"
+)


### PR DESCRIPTION
Call the `terraformCheckJob` build, which lints the Terraform files and runs git-secrets to check for keys that have been committed accidentally.