### PR TITLE
Add individual stage jobs

### DIFF
--- a/terraform/bastion/Jenkinsfile-check-intg
+++ b/terraform/bastion/Jenkinsfile-check-intg
@@ -1,0 +1,24 @@
+library("tdr-jenkinslib")
+def repo = "tdr-scripts"
+def tooOld = "False"
+
+pipeline {
+  agent {
+    label "master"
+  }
+  stages {
+    stage("Run git secrets") {
+      steps {
+        script {
+          build(
+              job: "TDR Bastion Check",
+              parameters: [
+                  string(name: "STAGE", value: "intg"),
+              ],
+              wait: false)
+        }
+      }
+    }
+  }
+}
+

--- a/terraform/bastion/Jenkinsfile-check-intg
+++ b/terraform/bastion/Jenkinsfile-check-intg
@@ -1,13 +1,9 @@
-library("tdr-jenkinslib")
-def repo = "tdr-scripts"
-def tooOld = "False"
-
 pipeline {
   agent {
     label "master"
   }
   stages {
-    stage("Run git secrets") {
+    stage("Run the bastion check for integration") {
       steps {
         script {
           build(

--- a/terraform/bastion/Jenkinsfile-check-prod
+++ b/terraform/bastion/Jenkinsfile-check-prod
@@ -1,13 +1,9 @@
-library("tdr-jenkinslib")
-def repo = "tdr-scripts"
-def tooOld = "False"
-
 pipeline {
   agent {
     label "master"
   }
   stages {
-    stage("Run git secrets") {
+    stage("Run the bastion check for prod") {
       steps {
         script {
           build(

--- a/terraform/bastion/Jenkinsfile-check-prod
+++ b/terraform/bastion/Jenkinsfile-check-prod
@@ -1,0 +1,24 @@
+library("tdr-jenkinslib")
+def repo = "tdr-scripts"
+def tooOld = "False"
+
+pipeline {
+  agent {
+    label "master"
+  }
+  stages {
+    stage("Run git secrets") {
+      steps {
+        script {
+          build(
+              job: "TDR Bastion Check",
+              parameters: [
+                  string(name: "STAGE", value: "prod"),
+              ],
+              wait: false)
+        }
+      }
+    }
+  }
+}
+

--- a/terraform/bastion/Jenkinsfile-check-staging
+++ b/terraform/bastion/Jenkinsfile-check-staging
@@ -1,13 +1,9 @@
-library("tdr-jenkinslib")
-def repo = "tdr-scripts"
-def tooOld = "False"
-
 pipeline {
   agent {
     label "master"
   }
   stages {
-    stage("Run git secrets") {
+    stage("Run the bastion check for staging") {
       steps {
         script {
           build(

--- a/terraform/bastion/Jenkinsfile-check-staging
+++ b/terraform/bastion/Jenkinsfile-check-staging
@@ -1,0 +1,24 @@
+library("tdr-jenkinslib")
+def repo = "tdr-scripts"
+def tooOld = "False"
+
+pipeline {
+  agent {
+    label "master"
+  }
+  stages {
+    stage("Run git secrets") {
+      steps {
+        script {
+          build(
+              job: "TDR Bastion Check",
+              parameters: [
+                  string(name: "STAGE", value: "staging"),
+              ],
+              wait: false)
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
The existing job will be called by three separate jobs, each on timers, for each of the environments. This allows us to split them between the integration and prod Jenkins.