### PR TITLE
Handle case where some release branches are missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ tdr-terraform-modules
 *.tfstate
 *.tfstate.backup
 terraform.tfstate.d
-
-venv

--- a/release-versions/.gitignore
+++ b/release-versions/.gitignore
@@ -1,0 +1,2 @@
+output.html
+

--- a/release-versions/.gitignore
+++ b/release-versions/.gitignore
@@ -1,2 +1,2 @@
+venv
 output.html
-

--- a/release-versions/generate_release_file.py
+++ b/release-versions/generate_release_file.py
@@ -16,6 +16,8 @@ def url(repo, suffix):
 
 
 def get_versions(repository_name):
+    print(f"Fetching release branches for {repository_name}")
+
     branches = requests.get(url(repository_name, "branches"), headers=headers).json()
     # If there are no branches found for a repository, you get a message field so we can just ignore those.
     filtered_release_branches = dict(ChainMap(*[{branch["name"]: branch} for branch in branches if


### PR DESCRIPTION
This fixes a bug where the release version script would fail because a new repo had been deployed to integration but not staging or prod.

Show the release version as "Unknown" in the table, and highlight it in red.

This introduces extra None handling, so also refactor the code to fetch branch details and generate view models to make the error handling simpler.