### PR TITLE
Add cross account permission to ECR

### DIFF
--- a/terraform/ecr-sandbox/root.tf
+++ b/terraform/ecr-sandbox/root.tf
@@ -5,3 +5,13 @@ resource "aws_ecr_repository" "sandbox_ecr_repository" {
     scan_on_push = true
   }
 }
+
+resource "aws_iam_policy" "ecr_cross_account_permission" {
+  name   = "TDRECRCrossAccountPermission${title(local.environment)}"
+  policy = templatefile("${path.module}/templates/ecr_cross_account_policy.json.tpl", { account_id = data.aws_ssm_parameter.management_account.value })
+}
+
+resource "aws_ecr_repository_policy" "mgmt_account_permission" {
+  policy     = aws_iam_policy.ecr_cross_account_permission.policy
+  repository = aws_ecr_repository.sandbox_ecr_repository.name
+}

--- a/terraform/ecr-sandbox/root_data.tf
+++ b/terraform/ecr-sandbox/root_data.tf
@@ -1,3 +1,7 @@
 data "aws_ssm_parameter" "cost_centre" {
   name = "/sandbox/cost_centre"
 }
+
+data "aws_ssm_parameter" "management_account" {
+  name = "/mgmt/management_account"
+}

--- a/terraform/ecr-sandbox/templates/ecr_cross_account_policy.json.tpl
+++ b/terraform/ecr-sandbox/templates/ecr_cross_account_policy.json.tpl
@@ -1,0 +1,21 @@
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPushPull",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${account_id}:root"
+      },
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
To allow for testing of Jenkins node image updates give management account permission to push and pull from sandbox ECR

This will supporting building ECR images via Jenkins, instead of being done on local developer machines