### PR TITLE
Increase github branch list size to maximum

### DIFF
--- a/release-versions/generate_release_file.py
+++ b/release-versions/generate_release_file.py
@@ -18,7 +18,7 @@ def url(repo, suffix):
 def get_versions(repository_name):
     print(f"Fetching release branches for {repository_name}")
 
-    branches = requests.get(url(repository_name, "branches"), headers=headers).json()
+    branches = requests.get(url(repository_name, "branches?per_page=100"), headers=headers).json()
     # If there are no branches found for a repository, you get a message field so we can just ignore those.
     filtered_release_branches = dict(ChainMap(*[{branch["name"]: branch} for branch in branches if
                                                 branch["name"] in ["release-intg", "release-staging",


### PR DESCRIPTION
GitHub API 'list-branches' defaults to 30 branches per page. The tdr-transfer-frontend repo has more than this

The 'release-staging' and 'release-prod' branches were missing from the result because of the size limit and were not appearing in summary as a result

Increase the per page limit to the maximum of 100