### PR TITLE
Run the release versions on a schedule.

### DIFF
--- a/.github/workflows/bastion_check.yml
+++ b/.github/workflows/bastion_check.yml
@@ -1,5 +1,4 @@
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '15 8 * * *'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,6 +1,8 @@
 name: Generate release versions
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '30 11 * * *'
 jobs:
   generate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The Jenkins one was running on a schedule but this isn't.

Jenkins was running around 11:30 so I've set this to be the same.

Also, stop running the bastion age check on push as that makes no sense.