### PR TITLE
Update the restore job and the bastion.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "terraform/bastion/tdr-terraform-modules"]
 	path = terraform/bastion/tdr-terraform-modules
 	url = https://github.com/nationalarchives/tdr-terraform-modules.git
+[submodule "terraform/restore-database/tdr-terraform-modules"]
+	path = terraform/restore-database/tdr-terraform-modules
+	url = https://github.com/nationalarchives/tdr-terraform-modules.git

--- a/terraform/bastion/root.tf
+++ b/terraform/bastion/root.tf
@@ -13,7 +13,7 @@ resource "aws_iam_role" "bastion_db_connect_role" {
 
 resource "aws_iam_policy" "bastion_db_connect_policy" {
   name   = "TDRBastionAccessDbPolicy${title(local.environment)}"
-  policy = templatefile("${path.module}/templates/bastion_access_db_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id, cluster_id = data.aws_rds_cluster.consignment_api.cluster_resource_id })
+  policy = templatefile("${path.module}/templates/bastion_access_db_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id, instance_id = data.aws_db_instance.consignment_api.resource_id })
 }
 
 resource "aws_iam_role_policy_attachment" "db_connect_policy_attach" {
@@ -37,11 +37,6 @@ resource "aws_iam_policy" "bastion_connect_to_export_efs_policy" {
   count  = local.export_efs_count
   name   = "TDRBastionExportEFSConnectPolicy${title(local.environment)}"
   policy = templatefile("${path.module}/templates/bastion_connect_to_efs.json.tpl", { file_system_arn = data.aws_efs_file_system.export_file_system.arn })
-}
-
-
-data "aws_db_instance" "instance" {
-  db_instance_identifier = tolist(data.aws_rds_cluster.consignment_api.cluster_members)[0]
 }
 
 resource "aws_iam_role_policy_attachment" "bastion_assume_db_role_attach" {
@@ -98,7 +93,7 @@ module "bastion_ec2_instance" {
   name        = "bastion"
   user_data   = "user_data_bastion"
   user_data_variables = {
-    db_host                       = split(":", data.aws_db_instance.instance.endpoint)[0],
+    db_host                       = split(":", data.aws_db_instance.consignment_api.endpoint)[0],
     account_number                = data.aws_caller_identity.current.account_id,
     environment                   = title(local.environment),
     backend_checks_file_system_id = data.aws_efs_file_system.backend_checks_file_system.id,

--- a/terraform/bastion/root_data.tf
+++ b/terraform/bastion/root_data.tf
@@ -8,20 +8,20 @@ data "aws_ami" "amazon_linux_ami" {
   most_recent = true
 }
 
-data "aws_rds_cluster" "consignment_api" {
-  cluster_identifier = split(".", data.aws_ssm_parameter.database_url.value)[0]
+data "aws_db_instance" "consignment_api" {
+  db_instance_identifier = split(".", data.aws_ssm_parameter.database_url.value)[0]
 }
 
 data "aws_ssm_parameter" "database_url" {
-  name = "/${local.environment}/${var.service}/database/url"
+  name = "/${local.environment}/${var.service}/instance/url"
 }
 
 data "aws_ssm_parameter" "database_username" {
-  name = "/${local.environment}/${var.service}/database/username"
+  name = "/${local.environment}/${var.service}/instance/username"
 }
 
 data "aws_ssm_parameter" "database_password" {
-  name = "/${local.environment}/${var.service}/database/password"
+  name = "/${local.environment}/${var.service}/instance/password"
 }
 
 data "aws_ssm_parameter" "mgmt_account_number" {
@@ -59,7 +59,7 @@ data "aws_vpc" "vpc" {
 }
 
 data "aws_security_group" "db_security_group" {
-  name = "consignmentapi-database-security-group-${local.environment}"
+  name = "tdr-consignment-api-database-instance-${local.environment}"
 }
 
 data "aws_security_group" "efs_backend_checks_security_group" {

--- a/terraform/bastion/templates/bastion_access_db_policy.json.tpl
+++ b/terraform/bastion/templates/bastion_access_db_policy.json.tpl
@@ -5,7 +5,7 @@
       "Effect": "Allow",
       "Action": "rds-db:connect",
       "Resource": [
-        "arn:aws:rds-db:eu-west-2:${account_id}:dbuser:${cluster_id}/bastion_user"
+        "arn:aws:rds-db:eu-west-2:${account_id}:dbuser:${instance_id}/bastion_user"
       ]
     }
   ]

--- a/terraform/restore-database/README.md
+++ b/terraform/restore-database/README.md
@@ -1,6 +1,6 @@
 # Restore a database
 
-This script creates a replica of an existing rds database from a snapshot. It also updates the database url parameter in the parameter store to point to the new database cluster.
+This script creates a replica of an existing rds database from a snapshot. It also updates the database url parameter in the parameter store to point to the new database instance.
 
 This script is intended to be used to recover lost data in an emergency if it has been accidentally deleted, or major problem has affected the main database.
 
@@ -27,19 +27,19 @@ terraform init
 terraform apply
 ```
 
-The restore may take 10-15 minutes depending on the size of the database when you run this. Terraform won't exit until the cluster is created.
+The restore may take 10-15 minutes depending on the size of the database when you run this. Terraform won't exit until the instance is created.
 
 ## Restart the service to pick up the new database
-This only needs to be run if you want to switch the API over to the new database cluster. If you're only planning to manually move the SQL over from the new cluster then this step can be skipped.
+This only needs to be run if you want to switch the API over to the new database instance. If you're only planning to manually move the SQL over from the new instance then this step can be skipped.
 ```
 aws ecs update-service --service $DB_NO_DASH_service_$PROFILE --cluster $DB_NO_DASH_$PROFILE --force-new-deployment
 ```
 
-## Copy parts of the data from one cluster to another.
+## Copy parts of the data from one instance to another.
 If you want to manually copy parts of the data from the old instance to the new one, you will need to [create a bastion](https://github.com/nationalarchives/tdr-scripts/actions/workflows/bastion_deploy.yml) and do this manually.
 
 ## Revert the changes
-This will need to be done whether or not you've switched the ECS service to the new cluster
+This will need to be done whether or not you've switched the ECS service to the new instance
 
 You need to run the [environments terraform](https://github.com/nationalarchives/tdr-terraform-environments) against the same environment. This will revert the change this terraform project has made to the database/url parameter and update the ECS service which forces a restart. Once this is done and the load balancer has switched to the new task, then run: 
 ```

--- a/terraform/restore-database/root.tf
+++ b/terraform/restore-database/root.tf
@@ -1,7 +1,7 @@
 resource "aws_ssm_parameter" "database_url" {
   name      = "/${local.environment}/${local.db_name}/database/url"
   type      = "SecureString"
-  value     = aws_rds_cluster.db_restore_cluster.endpoint
+  value     = aws_db_instance.restore_db_instance.endpoint
   overwrite = true
 }
 
@@ -11,35 +11,23 @@ resource "random_string" "identifier" {
   special = false
 }
 
-resource "aws_rds_cluster" "db_restore_cluster" {
+resource "aws_db_instance" "restore_db_instance" {
   restore_to_point_in_time {
-    source_cluster_identifier  = var.cluster_identifier
-    restore_type               = "copy-on-write"
-    use_latest_restorable_time = var.restore_time == "" ? true : null
-    restore_to_time            = var.restore_time == "" ? null : var.restore_time
+    source_db_instance_identifier = var.instance_identifier
+    use_latest_restorable_time    = var.restore_time == "" ? true : null
+    restore_time                  = var.restore_time == "" ? null : var.restore_time
   }
-  vpc_security_group_ids              = [data.aws_security_group.db_security_group.id]
-  engine                              = "aurora-postgresql"
-  iam_database_authentication_enabled = true
+  instance_class                      = "db.t3.medium"
   db_subnet_group_name                = data.aws_db_subnet_group.subnet_group.name
-  database_name                       = local.db_name
+  name                                = local.db_name
   final_snapshot_identifier           = "restored-${var.database}-final-snapshot-${random_string.identifier.result}-${local.environment}"
-  tags                                = local.common_tags
-}
-
-resource "aws_rds_cluster_instance" "database_instance" {
-  count                = 1
-  identifier_prefix    = "db-postgres-instance-${local.environment}"
-  cluster_identifier   = aws_rds_cluster.db_restore_cluster.id
-  engine               = "aurora-postgresql"
-  engine_version       = var.engine_version
-  instance_class       = "db.t3.medium"
-  db_subnet_group_name = data.aws_db_subnet_group.subnet_group.name
+  iam_database_authentication_enabled = true
+  vpc_security_group_ids              = [data.aws_security_group.db_security_group.id]
 }
 
 resource "aws_iam_policy" "iam_db_authentication_policy" {
   count  = local.attach_new_policy_count
-  policy = templatefile("./tdr-terraform-modules/iam_policy/templates/restored_db_access.json.tpl", { cluster_arn = "arn:aws:rds-db:${local.aws_region}:${var.tdr_account_number}:dbuser:${aws_rds_cluster.db_restore_cluster.cluster_resource_id}/consignment_api_user" })
+  policy = templatefile("./tdr-terraform-modules/iam_policy/templates/restored_db_access.json.tpl", { cluster_arn = "arn:aws:rds-db:${local.aws_region}:${var.tdr_account_number}:dbuser:${aws_db_instance.restore_db_instance.resource_id}/${local.user}" })
   name   = "RestoredDbAccessPolicy${title(local.environment)}"
 }
 

--- a/terraform/restore-database/root_data.tf
+++ b/terraform/restore-database/root_data.tf
@@ -3,7 +3,7 @@ data "aws_ssm_parameter" "cost_centre" {
 }
 
 data "aws_security_group" "db_security_group" {
-  name = "${local.db_name}-database-security-group-${local.environment}"
+  name = local.db_name == "consignmentapi" ? "tdr-consignment-api-database-instance-${local.environment}" : "${local.db_name}-database-security-group-${local.environment}"
 }
 
 data "aws_db_subnet_group" "subnet_group" {

--- a/terraform/restore-database/root_locals.tf
+++ b/terraform/restore-database/root_locals.tf
@@ -1,6 +1,7 @@
 locals {
   environment             = terraform.workspace
   db_name                 = replace(var.database, "-", "")
+  user                    = local.db_name == "consignmentapi" ? "consignment_api_user" : "keycloak_user"
   attach_new_policy_count = var.database == "consignment-api" ? 1 : 0
   aws_region              = "eu-west-2"
   assume_role             = "arn:aws:iam::${var.tdr_account_number}:role/TDRRestoreDbTerraformRole${title(local.environment)}"

--- a/terraform/restore-database/root_variables.tf
+++ b/terraform/restore-database/root_variables.tf
@@ -8,8 +8,8 @@ variable "restore_time" {
   default     = ""
 }
 
-variable "cluster_identifier" {
-  description = "The cluster identifier. See the README for how to find this"
+variable "instance_identifier" {
+  description = "The instance identifier. See the README for how to find this"
 }
 
 variable "engine_version" {


### PR DESCRIPTION
This moves the bastion over to use the new security group and the new
database instance rather than the cluster.

The restore database script has now been changed to work for a single
instance instead of a cluster.
