### PR TITLE
Approve bastion deployments

### DIFF
--- a/.github/scripts/check_ec2_instance_age.py
+++ b/.github/scripts/check_ec2_instance_age.py
@@ -13,10 +13,11 @@ client = boto3.client("ec2")
 resp = client.describe_instances(Filters=[{'Name': 'tag:Name', 'Values': [instance_name]}])
 
 reservations = resp["Reservations"]
-if len(reservations) > 0:
-    instances = reservations[0]["Instances"][0]
-    launch_time = reservations[0]["Instances"][0]["LaunchTime"]
-    now = datetime.now(launch_time.tzinfo)
-    print(f"::set-output name=bastion-age::{(now - launch_time).days > int(age)}")
-else:
-    print("::set-output name=bastion-age::False")
+# if len(reservations) > 0:
+#     instances = reservations[0]["Instances"][0]
+#     launch_time = reservations[0]["Instances"][0]["LaunchTime"]
+#     now = datetime.now(launch_time.tzinfo)
+#     print(f"::set-output name=bastion-age::{(now - launch_time).days > int(age)}")
+# else:
+#     print("::set-output name=bastion-age::False")
+print("::set-output name=bastion-age::True")

--- a/.github/scripts/check_ec2_instance_age.py
+++ b/.github/scripts/check_ec2_instance_age.py
@@ -13,11 +13,10 @@ client = boto3.client("ec2")
 resp = client.describe_instances(Filters=[{'Name': 'tag:Name', 'Values': [instance_name]}])
 
 reservations = resp["Reservations"]
-# if len(reservations) > 0:
-#     instances = reservations[0]["Instances"][0]
-#     launch_time = reservations[0]["Instances"][0]["LaunchTime"]
-#     now = datetime.now(launch_time.tzinfo)
-#     print(f"::set-output name=bastion-age::{(now - launch_time).days > int(age)}")
-# else:
-#     print("::set-output name=bastion-age::False")
-print("::set-output name=bastion-age::True")
+if len(reservations) > 0:
+    instances = reservations[0]["Instances"][0]
+    launch_time = reservations[0]["Instances"][0]["LaunchTime"]
+    now = datetime.now(launch_time.tzinfo)
+    print(f"::set-output name=bastion-age::{(now - launch_time).days > int(age)}")
+else:
+    print("::set-output name=bastion-age::False")

--- a/.github/scripts/run-and-approve-bastion-destroy.sh
+++ b/.github/scripts/run-and-approve-bastion-destroy.sh
@@ -1,0 +1,5 @@
+gh workflow run bastion_deploy.yml -f environment=$1 -f command=destroy -f connect-to-database=false -f connect-to-backend-checks-efs=false -f connect-to-export-efs=false
+sleep 10
+RUN_ID=$(gh api -H 'Accept: application/vnd.github+json' "/repos/nationalarchives/tdr-scripts/actions/runs?status=waiting" | jq '.workflow_runs[0].id')
+ENVIRONMENT_ID=$(gh api -H "Accept: application/vnd.github+json" /repos/nationalarchives/tdr-scripts/environments/$1| jq '.id')
+curl -X POST  -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/nationalarchives/tdr-scripts/actions/runs/$RUN_ID/pending_deployments  -d "{\"environment_ids\":[$ENVIRONMENT_ID],\"state\":\"approved\",\"comment\":\"\"}" | jq '.[0].url'

--- a/.github/workflows/bastion_check.yml
+++ b/.github/workflows/bastion_check.yml
@@ -34,7 +34,7 @@ jobs:
           pip install boto3
           python ./.github/scripts/check_ec2_instance_age.py ${{ secrets[steps.set-environment-names.outputs.account-number-secret] }} ${{ matrix.environment }} bastion-ec2-instance-${{ matrix.environment }} 1
       - if: ${{ steps.get-age.outputs.bastion-age == 'True' }}
-        run: ./.github/scripts/run-and-approve-bastion-destroy.sh
+        run: ./.github/scripts/run-and-approve-bastion-destroy.sh ${{ matrix.environment }}
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
       - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main

--- a/.github/workflows/bastion_check.yml
+++ b/.github/workflows/bastion_check.yml
@@ -34,7 +34,7 @@ jobs:
           pip install boto3
           python ./.github/scripts/check_ec2_instance_age.py ${{ secrets[steps.set-environment-names.outputs.account-number-secret] }} ${{ matrix.environment }} bastion-ec2-instance-${{ matrix.environment }} 1
       - if: ${{ steps.get-age.outputs.bastion-age == 'True' }}
-        run: gh workflow run bastion_deploy.yml -f environment=${{ matrix.environment }} -f command=destroy -f connect-to-database=false -f connect-to-backend-checks-efs=false -f connect-to-export-efs=false
+        run: ./.github/scripts/run-and-approve-bastion-destroy.sh
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
       - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main


### PR DESCRIPTION
Approve bastion deployments.
    
This will trigger the bastion job, wait for it to get to the correct state and then approve it as at the moment, it needs a manual approval.

I think this is safe because the worst anyone can do is trigger the job which will delete the bastion if it's old enough which is what we want anyway.
