### PR TITLE
Remove connect-to-backend-checks-efs parameter.

### DIFF
--- a/.github/scripts/run-and-approve-bastion-destroy.sh
+++ b/.github/scripts/run-and-approve-bastion-destroy.sh
@@ -1,4 +1,4 @@
-gh workflow run bastion_deploy.yml -f environment=$1 -f command=destroy -f connect-to-database=false -f connect-to-backend-checks-efs=false -f connect-to-export-efs=false
+gh workflow run bastion_deploy.yml -f environment=$1 -f command=destroy -f connect-to-database=false -f connect-to-export-efs=false
 sleep 10
 RUN_ID=$(gh api -H 'Accept: application/vnd.github+json' "/repos/nationalarchives/tdr-scripts/actions/runs?status=waiting" | jq '.workflow_runs[0].id')
 ENVIRONMENT_ID=$(gh api -H "Accept: application/vnd.github+json" /repos/nationalarchives/tdr-scripts/environments/$1| jq '.id')


### PR DESCRIPTION
This is the check job which deletes any bastion older than 2 days by
calling the destroy bastion job.

It's still passing in the connect-to-backend-checks-efs which isn't
there any more so it's failing.
