### PR TITLE
TDR 2923 fix deprecation warnings

### DIFF
--- a/.github/scripts/check_ec2_instance_age.py
+++ b/.github/scripts/check_ec2_instance_age.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from datetime import datetime
 import boto3
@@ -13,10 +14,11 @@ client = boto3.client("ec2")
 resp = client.describe_instances(Filters=[{'Name': 'tag:Name', 'Values': [instance_name]}])
 
 reservations = resp["Reservations"]
-if len(reservations) > 0:
-    instances = reservations[0]["Instances"][0]
-    launch_time = reservations[0]["Instances"][0]["LaunchTime"]
-    now = datetime.now(launch_time.tzinfo)
-    print(f"::set-output name=bastion-age::{(now - launch_time).days > int(age)}")
-else:
-    print("::set-output name=bastion-age::False")
+with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    if len(reservations) > 0:
+        instances = reservations[0]["Instances"][0]
+        launch_time = reservations[0]["Instances"][0]["LaunchTime"]
+        now = datetime.now(launch_time.tzinfo)
+        print(f'bastion-age={(now - launch_time).days > int(age)}', file=fh)
+    else:
+        print("bastion-age=False", file=fh)

--- a/.github/workflows/bastion_check.yml
+++ b/.github/workflows/bastion_check.yml
@@ -19,9 +19,11 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}
       - id: set-environment-names
         run: |
+          import os
           env = "${{ matrix.environment }}"
-          run: print(f"::set-output name=title-environment::{env.title()}")
-          print(f"::set-output name=account-number-secret::{env.upper()}_ACCOUNT_NUMBER")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f"title-environment={env.title()}", file=fh)
+            print(f"account-number-secret={env.upper()}_ACCOUNT_NUMBER", file=fh)
         shell: python
       - id: configure-aws-credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/bastion_deploy.yml
+++ b/.github/workflows/bastion_deploy.yml
@@ -42,7 +42,7 @@ jobs:
         run: | 
           import os
           with open(os.environ['GITHUB_OUTPUT'], 'a') as fh: 
-            print(f'title-environment={'${{ github.event.inputs.environment }}'.title()}', file=fh)
+            print(f'title-environment={"${{ github.event.inputs.environment }}".title()}', file=fh)
         shell: python
       - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
       - id: configure-aws-credentials

--- a/.github/workflows/bastion_deploy.yml
+++ b/.github/workflows/bastion_deploy.yml
@@ -39,7 +39,10 @@ jobs:
           submodules: recursive
           token: ${{ secrets.WORKFLOW_PAT }}
       - id: set-environment-names
-        run: print(f"::set-output name=title-environment::{'${{ github.event.inputs.environment }}'.title()}")
+        run: | 
+          import os
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh: 
+            print(f'title-environment={'${{ github.event.inputs.environment }}'.title()}', file=fh)
         shell: python
       - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
       - id: configure-aws-credentials


### PR DESCRIPTION
Replace set-output with writing to $GITHUB_OUTPUT

This is as GitHub recommend here https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I did think about creating this as a custom action but there doesn't seem to be any neat way to pass in key value pairs to a custom action so it would end up being more unwieldy than this.


