### PR TITLE
Set up terraform later in bastion deploy workflow

### DIFF
--- a/.github/workflows/bastion_deploy.yml
+++ b/.github/workflows/bastion_deploy.yml
@@ -44,7 +44,6 @@ jobs:
         working-directory: ./terraform/bastion
     steps:
       - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v1
         with:
           submodules: recursive
           token: ${{ secrets.WORKFLOW_PAT }}
@@ -80,6 +79,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/TDRGithubTerraformAssumeRole${{ steps.set-environment-names.outputs.title-environment }}
           aws-region: eu-west-2
           role-session-name: TerraformRole
+      - uses: hashicorp/setup-terraform@v1
       - name: Run Terraform
         env:
           TF_VAR_tdr_account_number: ${{ secrets.ACCOUNT_NUMBER }}

--- a/.github/workflows/bastion_deploy.yml
+++ b/.github/workflows/bastion_deploy.yml
@@ -39,6 +39,9 @@ jobs:
   deploy:
     environment: ${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/bastion
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v1
@@ -84,7 +87,6 @@ jobs:
           TF_VAR_connect_to_database: ${{ github.event.inputs.connect-to-database }}
           TF_VAR_connect_to_export_efs: ${{ github.event.inputs.connect-to-export-efs }}
         run: |
-          cd terraform/bastion
           terraform --version
           terraform init
           terraform workspace new ${{ github.event.inputs.environment }} || true

--- a/.github/workflows/bastion_deploy.yml
+++ b/.github/workflows/bastion_deploy.yml
@@ -39,9 +39,6 @@ jobs:
   deploy:
     environment: ${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./terraform/bastion
     steps:
       - uses: actions/checkout@v3
         with:
@@ -87,6 +84,7 @@ jobs:
           TF_VAR_connect_to_database: ${{ github.event.inputs.connect-to-database }}
           TF_VAR_connect_to_export_efs: ${{ github.event.inputs.connect-to-export-efs }}
         run: |
+          cd terraform/bastion
           terraform --version
           terraform init
           terraform workspace new ${{ github.event.inputs.environment }} || true


### PR DESCRIPTION
Looks like terraform setup needs to take place after checkout (and submodule resolution) as otherwise terraform is unable to recognise the submodules on initialising.